### PR TITLE
Auto-generation of testRunId. Config property names made consistent.

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Influx = require('influx'),
+    uuid = require('uuid'),
     constants = {
         PLUGIN_NAME: 'influxdb',
 
@@ -11,7 +12,8 @@ var Influx = require('influx'),
         STATUS_CODE: 3,
 
         // required configuration names
-        CONFIG_TEST_NAME: 'test_name',
+        CONFIG_TEST_NAME: 'testName',
+        CONFIG_TEST_RUN_ID: 'testRunId',
         CONFIG_INFLUX: 'influx',
         CONFIG_INFLUX_HOST: 'host',
         CONFIG_INFLUX_USERNAME: 'username',
@@ -84,6 +86,11 @@ var Influx = require('influx'),
             // It must provide a test name.
             if (!scriptConfig[constants.CONFIG_TEST_NAME]) {
                 throw new Error(messages.pluginParamIsRequired.replace(constants.MSG_PARAM, constants.CONFIG_TEST_NAME));
+            }
+
+            // If no testRunId is provided, generate one.
+            if (!scriptConfig[constants.CONFIG_TEST_RUN_ID]) {
+                scriptConfig[constants.CONFIG_TEST_RUN_ID] = uuid.v4();
             }
 
             // Check each of the influx-specific settings and validate.

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -13,6 +13,7 @@ var Influx = require('influx'),
 
         // required configuration names
         CONFIG_TEST_NAME: 'testName',
+        CONFIG_TEST_NAME_ALT: 'test_name',  // TODO: Remove back-compatible name when v1.0.0 released
         CONFIG_TEST_RUN_ID: 'testRunId',
         CONFIG_INFLUX: 'influx',
         CONFIG_INFLUX_HOST: 'host',
@@ -83,9 +84,16 @@ var Influx = require('influx'),
 
             impl.determineInfluxLoginCredentials(scriptConfig);
 
-            // It must provide a test name.
-            if (!scriptConfig[constants.CONFIG_TEST_NAME]) {
+            // It must provide a test name; alternate version accepted.
+            // TODO: Remove back-compatible name when v1.0.0 released
+            if (!scriptConfig[constants.CONFIG_TEST_NAME] && !scriptConfig[constants.CONFIG_TEST_NAME_ALT]) {
                 throw new Error(messages.pluginParamIsRequired.replace(constants.MSG_PARAM, constants.CONFIG_TEST_NAME));
+            }
+
+            // Use the alternate test name if other does not exist
+            // TODO: Remove back-compatible name when v1.0.0 released
+            if (!scriptConfig[constants.CONFIG_TEST_NAME]) {
+                scriptConfig[constants.CONFIG_TEST_NAME] = scriptConfig[constants.CONFIG_TEST_NAME_ALT];
             }
 
             // If no testRunId is provided, generate one.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/nordstrom/artillery-plugin-influxdb#readme",
   "dependencies": {
-    "influx": "^4.2.0"
+    "influx": "^4.2.0",
+    "uuid": "^2.0.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/test.js
+++ b/test/test.js
@@ -48,7 +48,23 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
         }).not.to.throw();
     });
 
-    it('requires testName in the configuration', function() {
+    it('accepts an uses old test_name configuration value', function() {
+        expect(function() {
+            Plugin.impl.validateConfig({
+                test_name: 'this is a valid test name',
+                influx: {
+                    host: 'my-test-host-name',
+                    username: 'a-user',
+                    password: 'p@ssw0rd',
+                    database: 'any-db-name'
+                }
+            });
+        }).not.to.throw();
+
+        expect(Plugin.impl.config.testName).to.equal('this is a valid test name');
+    });
+
+    it('requires testName or test_name in the configuration', function() {
         expect(function() {
             Plugin.impl.validateConfig({
                 influx: {

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,7 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
     it('accepts a valid configuration', function() {
         expect(function() {
             Plugin.impl.validateConfig({
-                test_name: 'this is a valid test name',
+                testName: 'this is a valid test name',
                 influx: {
                     host: 'my-test-host-name',
                     username: 'a-user',
@@ -48,7 +48,7 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
         }).not.to.throw();
     });
 
-    it('requires test_name in the configuration', function() {
+    it('requires testName in the configuration', function() {
         expect(function() {
             Plugin.impl.validateConfig({
                 influx: {
@@ -58,13 +58,13 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
                     database: 'any-db-name'
                 }
             });
-        }).to.throw(Error, /test_name/);
+        }).to.throw(Error, /testName/);
     });
 
     it('requires influx.host in the configuration', function() {
         expect(function() {
             Plugin.impl.validateConfig({
-                test_name: 'this is a valid test name',
+                testName: 'this is a valid test name',
                 influx: {
                     username: 'a-user',
                     password: 'p@ssw0rd',
@@ -79,7 +79,7 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
 
         expect(function() {
             Plugin.impl.validateConfig({
-                test_name: 'this is a valid test name',
+                testName: 'this is a valid test name',
                 influx: {
                     host: 'my-test-host-name',
                     password: 'p@ssw0rd',
@@ -92,7 +92,7 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
     it('requires influx.username in the configuration or environment', function() {
         expect(function() {
             Plugin.impl.validateConfig({
-                test_name: 'this is a valid test name',
+                testName: 'this is a valid test name',
                 influx: {
                     host: 'my-test-host-name',
                     password: 'p@ssw0rd',
@@ -107,7 +107,7 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
 
         expect(function() {
             Plugin.impl.validateConfig({
-                test_name: 'this is a valid test name',
+                testName: 'this is a valid test name',
                 influx: {
                     host: 'my-test-host-name',
                     username: 'a-user',
@@ -120,7 +120,7 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
     it('requires influx.password in the configuration or environment', function() {
         expect(function() {
             Plugin.impl.validateConfig({
-                test_name: 'this is a valid test name',
+                testName: 'this is a valid test name',
                 influx: {
                     host: 'my-test-host-name',
                     username: 'a-user',
@@ -133,7 +133,7 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
     it('requires influx.database in the configuration', function() {
         expect(function() {
             Plugin.impl.validateConfig({
-                test_name: 'this is a valid test name',
+                testName: 'this is a valid test name',
                 influx: {
                     host: 'my-test-host-name',
                     username: 'a-user',
@@ -141,6 +141,27 @@ describe('Artillery Influx DB plug-in must correctly validate configurations', f
                 }
             });
         }).to.throw(Error, /influx.database/);
+    });
+
+    it('will generate a testRunId if one is not provided', function() {
+        expect(function() {
+            Plugin.impl.validateConfig({
+                testName: 'this is a valid test name',
+                influx: {
+                    host: 'my-test-host-name',
+                    username: 'a-user',
+                    password: 'p@ssw0rd',
+                    database: 'any-db-name'
+                }
+            });
+        }).not.to.throw();
+
+        /*jshint -W030 */
+        expect(Plugin.impl.config.testRunId).not.to.be.undefined;
+        expect(Plugin.impl.config.testRunId).not.to.be.null;
+        /*jshint +W030 */
+        expect(Plugin.impl.config.testRunId).to.be.a('string');
+        expect(Plugin.impl.config.testRunId.length).to.equal(36);
     });
 });
 
@@ -152,7 +173,7 @@ describe('Artillery Influx DB plug-in must report results once testing is comple
         new Plugin({
                 plugins: {
                     influxdb: {
-                        test_name: '45215-PERS-FDN-PreferredStore-Get-test-loadAndMonitor',
+                        testName: '45215-PERS-FDN-PreferredStore-Get-test-loadAndMonitor',
                         influx: {
                             host: 'ec2-52-10-71-7.us-west-2.compute.amazonaws.com',
                             username: 'artillery_reporter',


### PR DESCRIPTION
Doing a formal PR as changing the name for the required config property "test_name" to "testName" which is a breaking change for any existing configuration out there. This makes the properties more consistent with those of Artillery IO (e.g. beforeRequest).