### PR TITLE
Adds work-around for shift in reporting schema on 'stats' event from artillery-core.

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -133,6 +133,11 @@ var Influx = require('influx'),
                 samples = 0,
                 sample;
 
+            // Work around change in testReport schema in artillery-core (Issue #3)
+            if (testReport._entries) {
+                testReport.latencies = testReport._entries;
+            }
+
             // For each of the latencies, create a point for influx,
             // adding any static tags from the config.
             while (samples < testReport.latencies.length) {
@@ -157,6 +162,11 @@ var Influx = require('influx'),
         reportErrors: function (instance, influxReporter, testReport) {
             var errorCount = 0,
                 points = [];
+
+            // Work around change in testReport schema in artillery-core (Issue #3)
+            if (testReport._errors) {
+                testReport.errors = testReport._errors;
+            }
 
             // If there are no errors or error measurement name not defined (or empty), then exit.
             if (!testReport.errors || !instance.config[constants.CONFIG_STATIC_TAGS]) {

--- a/test/test.js
+++ b/test/test.js
@@ -277,6 +277,14 @@ describe('Artillery Influx DB plug-in must report results once testing is comple
         });
     }
 
+    function reportLatenciesNewSchema(latencies, errors) {
+        // Simulate artillery results event by calling into the report function
+        onEventHooks[0].actualReportFunction({
+            _entries: latencies,
+            _errors: errors
+        });
+    }
+
     beforeEach(function() {
         influxWriteInvocations = [];
         onEventHooks = [];
@@ -310,6 +318,19 @@ describe('Artillery Influx DB plug-in must report results once testing is comple
         /*jshint +W030 */
     });
 
+    it('uses influx to write results once stats event is raised - supports updated schema', function() {
+        /*jshint -W030 */
+        expect(onEventHooks[0].actualReportFunction).to.not.be.null;
+        expect(onEventHooks[0].actualReportFunction).to.not.be.undefined;
+        /*jshint +W030 */
+
+        reportLatenciesNewSchema([]);
+
+        /*jshint -W030 */
+        expect(influxWriteInvocations[0].points).to.not.be.null;
+        /*jshint +W030 */
+    });
+
     it('will raise an exception if an error is returned when reporting to InfluxDB', function() {
         reportLatencies([]);
 
@@ -320,6 +341,14 @@ describe('Artillery Influx DB plug-in must report results once testing is comple
 
     it('will not raise an exception if an error is not returned when reporting from InfluxDB', function() {
         reportLatencies([]);
+
+        expect(function() {
+            influxWriteInvocations[0].callback(null);
+        }).to.not.throw();
+    });
+
+    it('will not raise an exception if an error is not returned when reporting from InfluxDB when new schema is used', function() {
+        reportLatenciesNewSchema([]);
 
         expect(function() {
             influxWriteInvocations[0].callback(null);


### PR DESCRIPTION
This is a fix for issue #6 not 3. LOLs.

@erikerikson can you have a look, please? Seems like this'll block the workshop. TY!