### PR TITLE
Added ability to render environment variables

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -43,11 +43,29 @@ var Influx = require('influx'),
         metricsReportedToInflux: '%s metrics reported to InfluxDB.'
     },
     impl = {
-        handleError: function(message) {
+        handleError: function (message) {
             console.error(message);
             throw new Error(message);
         },
-        determineInfluxLoginCredentials: function(pluginConfig) {
+        renderVariables: function (config, vars) {
+            const lens = (obj, path) => path.split('.').reduce((o, key) => o && o[key] ? o[key] : null, obj);
+
+            let configStr = JSON.stringify(config);
+            const RX = /{{{?[\s$\w.]+}}}?/g;
+            let result = configStr.substring(0, configStr.length)
+
+            while (result.search(RX) > -1) {
+                let templateStr = result.match(RX)[0]
+                const varName = templateStr.replace(/{/g, '').replace(/}/g, '').trim()
+                let varValue = lens(vars, varName)
+                if (typeof varValue === 'object') {
+                    varValue = JSON.stringify(varValue)
+                }
+                result = result.replace(templateStr, varValue);
+            }
+            return JSON.parse(result);
+        },
+        determineInfluxLoginCredentials: function (pluginConfig) {
             function setFromConfigOrEnv(configName, envName) {
                 // Check to see if value is provided in config
                 if (!pluginConfig[constants.CONFIG_INFLUX][configName]) {
@@ -109,19 +127,19 @@ var Influx = require('influx'),
             }
 
             // Check each of the influx-specific settings and validate.
-            requiredInfluxConfigs.forEach(function(configName) {
-                    if (!scriptConfig[constants.CONFIG_INFLUX][configName]) {
-                        impl.handleError(util.format(messages.pluginParamIsRequired, constants.CONFIG_INFLUX + '.' + configName));
-                    }
+            requiredInfluxConfigs.forEach(function (configName) {
+                if (!scriptConfig[constants.CONFIG_INFLUX][configName]) {
+                    impl.handleError(util.format(messages.pluginParamIsRequired, constants.CONFIG_INFLUX + '.' + configName));
+                }
 
-                    // Check that host is name only: no protocol or port.
-                    if (configName === constants.CONFIG_INFLUX_HOST) {
-                        var host = scriptConfig[constants.CONFIG_INFLUX][configName];
-                        if (host.indexOf(':') > -1 || host.indexOf('/') > -1) {
-                            impl.handleError(util.format(messages.influxdbHostMustBeHostname, constants.CONFIG_INFLUX + '.' + configName));
-                        }
+                // Check that host is name only: no protocol or port.
+                if (configName === constants.CONFIG_INFLUX_HOST) {
+                    var host = scriptConfig[constants.CONFIG_INFLUX][configName];
+                    if (host.indexOf(':') > -1 || host.indexOf('/') > -1) {
+                        impl.handleError(util.format(messages.influxdbHostMustBeHostname, constants.CONFIG_INFLUX + '.' + configName));
                     }
                 }
+            }
             );
 
             return scriptConfig;
@@ -190,7 +208,7 @@ var Influx = require('influx'),
             }
 
             // For each of the error types reported, create a point for influx.
-            Object.getOwnPropertyNames(testReport.errors).forEach(function(propertyName) {
+            Object.getOwnPropertyNames(testReport.errors).forEach(function (propertyName) {
                 errorCount += testReport.errors[propertyName];
             });
 
@@ -224,8 +242,13 @@ var Influx = require('influx'),
                 impl.handleError(constants.pluginsConfigNotFound);
             }
 
+            // Render context variables
+            // Currently only support environment variables
+            let vars = { "$processEnvironment": process.env };
+            let config = impl.renderVariables(scriptConfig.plugins[constants.PLUGIN_NAME], vars);
+
             // Validate the settings provided for our specific Plugin.
-            this.config = impl.validateConfig(scriptConfig.plugins[constants.PLUGIN_NAME]);
+            this.config = impl.validateConfig(config);
 
             // Create a reporting client and attach to DONE event from Artillery.
             reporter = impl.createReporter(this.config);

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -11,6 +11,8 @@ var Influx = require('influx'),
         REQUEST_ID: 1,
         LATENCY: 2,
         STATUS_CODE: 3,
+        REQ_INFO: 4,
+        SCENARIO_NAME: 5,
 
         // required configuration names
         CONFIG_TEST_NAME: 'testName',
@@ -173,14 +175,20 @@ var Influx = require('influx'),
                         time: sample[constants.TIMESTAMP],
                         value: sample[constants.LATENCY] / 1000000
                     }, Object.assign({
-                        response: sample[constants.STATUS_CODE]
+                        response: sample[constants.STATUS_CODE],
+                        scenarioName: sample[constants.SCENARIO_NAME],
+                        requestUrl: sample[constants.REQ_INFO].url,
+                        httpMethod: sample[constants.REQ_INFO].method
                     }, instance.config[constants.CONFIG_STATIC_TAGS])]);
                 } else {
                     points.push([{
                         time: sample[constants.TIMESTAMP],
                         value: sample[constants.LATENCY] / 1000000
                     }, Object.assign({
-                        response: sample[constants.STATUS_CODE]
+                        response: sample[constants.STATUS_CODE],
+                        scenarioName: sample[constants.SCENARIO_NAME],
+                        requestUrl: sample[constants.REQ_INFO].url,
+                        httpMethod: sample[constants.REQ_INFO].method
                     }, instance.config[constants.CONFIG_STATIC_TAGS])]);
                 }
             }


### PR DESCRIPTION
Artillery does not appear to render environment variables within the plugin section of the script.  This PR enables the plugin to render $processEnvironment.[VariableName] within useful things like tags.  

Things feature becomes handy when trying to add a `region` tag to the metric containing the environment variable `AWS_REGION` when running inside a lambda function.

Something similar to the following excerpt will now work as expected
```
plugins:
    influxdb:
      testName: "Ramp to 100/120 Sustain 100/180"
      tags:
        region: "{{ $processEnvironment.AWS_REGION }}"
      influx:
        host: "[your-api-gateway.url]"
        username: "test"
        password: "test"
        database: "multi_region_metrics"
```